### PR TITLE
Ensure jacks don't double up

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A simple patch might look like:
 ```
 sequencer[bpm: 90](output)
   -> (trigger)envelope[A:0, D:2, S:0, R:2](out)
-  -> (control)sine[Level: 10, Tone: 1.5](out);
+  -> (control)sine[Level: 10, Tone: 1.5];
 ```
 
 This, in essence, says
@@ -41,7 +41,7 @@ A module, such as `(trigger)envelope[A:0, D:2, S:0, R:2](out)` is made up of:
 * `envelope[A:0, D:2, S:0, R:2]` - the module its self (`envelope`) and whichever knobs and twiddler values apply
 * `(out)` - the output jack
 
-There is one special case; the first module in a patch. This will error if an input jack is set, since setting an input to the first module is an absurdity.
+There are two special cases; the first module in a patch, and the last module in a patch. The first must not have an input, and the last must not have an output since this would be an absurdity.
 
 Finally, a patch ends with a semicolon; this allows us to add many patches to a single input file, should we want to.
 
@@ -52,7 +52,7 @@ The following [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_
 ```ebnf
 SynthdownFile = (Patch ";")* .
 Patch = Module ("-" ">" Module)* .
-Module = Jack? <ident> "[" Arg* ("," Arg)* "]" Jack .
+Module = Jack? <ident> "[" Arg* ("," Arg)* "]" Jack? .
 Jack = "(" <ident> ")" .
 Arg = <ident> ":" Value .
 Value = <string> | <float> | <int> .

--- a/patch.go
+++ b/patch.go
@@ -23,6 +23,45 @@ func (e FirstPatchHasInputError) Error() string {
 	return fmt.Sprintf("the first module of the patch described at %s has an input", e.m.Pos)
 }
 
+// LastPatchHasOutputError is an error signifying that the
+// patch starts with an output, which is a logical absurdity; if it
+// has an output from _somewhere_ then it cannot be the start of a patch
+// unless it plugs into its self, or is a snippet.
+//
+// Neither of which are supported, and wont be until we suddenly realise
+// it should be
+type LastPatchHasOutputError struct {
+	m Module
+}
+
+// Error satisifies the `error` interface, returning a message explaining
+// where the errant initial output lives
+func (e LastPatchHasOutputError) Error() string {
+	return fmt.Sprintf("the last module of the patch described at %s has an output", e.m.Pos)
+}
+
+// MissingInputError is raised where a module should have an input, but
+// doesn't
+type MissingInputError struct {
+	m Module
+}
+
+// Error returns an explanation of which module is missing an input jack
+func (e MissingInputError) Error() string {
+	return fmt.Sprintf("missing input jack at %s", e.m.Pos)
+}
+
+// MissingOutputError is raised where a module should have an output, but
+// doesn't
+type MissingOutputError struct {
+	m Module
+}
+
+// Error returns an explanation of which module is missing an output jack
+func (e MissingOutputError) Error() string {
+	return fmt.Sprintf("missing output jack at %s", e.m.Pos)
+}
+
 // Patch represents a set of modules cabled together from jack to jack
 // which hopefully makes an interesting noise
 type Patch struct {
@@ -43,6 +82,29 @@ func (p Patch) Validate() (err error) {
 	first := p.Modules[0]
 	if first.Input != nil {
 		return FirstPatchHasInputError{first}
+	}
+
+	// Ensure the last module _doesn't_ have an output
+	last := p.Modules[modulesLen-1]
+	if last.Output != nil {
+		return LastPatchHasOutputError{last}
+	}
+
+	if modulesLen <= 2 {
+		return
+	}
+
+	// Ensure every other module has an input and an output
+	for i := 1; i < modulesLen-1; i++ {
+		mod := p.Modules[i]
+
+		if mod.Input == nil {
+			return MissingInputError{mod}
+		}
+
+		if mod.Output == nil {
+			return MissingOutputError{mod}
+		}
 	}
 
 	return

--- a/patch_test.go
+++ b/patch_test.go
@@ -35,6 +35,120 @@ func TestPatch_Errors(t *testing.T) {
 				},
 			},
 		}, "the first module of the patch described at test.sdown:1:1 has an input"},
+		{"last module has an input", Patch{
+			Modules: []Module{
+				{
+					Pos: lexer.Position{
+						Filename: "test.sdown",
+						Offset:   10,
+						Line:     1,
+						Column:   1,
+					},
+					Output: &Jack{
+						Name: "trigger",
+					},
+					Name: "flooper",
+					Args: []Arg{
+						{
+							Key:   "F",
+							Value: &Value{},
+						},
+					},
+				},
+			},
+		}, "the last module of the patch described at test.sdown:1:1 has an output"},
+		{"midde module is missing an input", Patch{
+			Modules: []Module{
+				{
+					Output: &Jack{
+						Name: "trigger",
+					},
+					Name: "flooper",
+					Args: []Arg{
+						{
+							Key:   "F",
+							Value: &Value{},
+						},
+					},
+				},
+				{
+					Pos: lexer.Position{
+						Filename: "test.sdown",
+						Offset:   10,
+						Line:     1,
+						Column:   1,
+					},
+					Output: &Jack{
+						Name: "cv1",
+					},
+					Name: "fridgefreezer",
+					Args: []Arg{
+						{
+							Key:   "Ytho",
+							Value: &Value{},
+						},
+					},
+				},
+				{
+					Input: &Jack{
+						Name: "in",
+					},
+					Name: "flimflammer",
+					Args: []Arg{
+						{
+							Key:   "X",
+							Value: &Value{},
+						},
+					},
+				},
+			},
+		}, "missing input jack at test.sdown:1:1"},
+		{"midde module is missing an output", Patch{
+			Modules: []Module{
+				{
+					Output: &Jack{
+						Name: "trigger",
+					},
+					Name: "flooper",
+					Args: []Arg{
+						{
+							Key:   "F",
+							Value: &Value{},
+						},
+					},
+				},
+				{
+					Pos: lexer.Position{
+						Filename: "test.sdown",
+						Offset:   10,
+						Line:     1,
+						Column:   1,
+					},
+					Input: &Jack{
+						Name: "cv1",
+					},
+					Name: "fridgefreezer",
+					Args: []Arg{
+						{
+							Key:   "Ytho",
+							Value: &Value{},
+						},
+					},
+				},
+				{
+					Input: &Jack{
+						Name: "in",
+					},
+					Name: "flimflammer",
+					Args: []Arg{
+						{
+							Key:   "X",
+							Value: &Value{},
+						},
+					},
+				},
+			},
+		}, "missing output jack at test.sdown:1:1"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.p.Validate()

--- a/synthdown-cli/cmd/testdata/complex.sdown
+++ b/synthdown-cli/cmd/testdata/complex.sdown
@@ -1,3 +1,3 @@
-square[](out) -> (c1)mixer[c1:10, out:10](out) -> (in)speaker[](out);
-saw[](out) -> (c2)mixer[c2:10](out);
-sine[](out) -> (c3)mixer[c3:7.5](out);
+square[](out) -> (c1)mixer[c1:10, out:10](out) -> (in)speaker[];
+saw[](out) -> (c2)mixer[c2:10];
+sine[](out) -> (c3)mixer[c3:7.5];

--- a/synthdown_file.go
+++ b/synthdown_file.go
@@ -7,10 +7,26 @@ import (
 	"github.com/alecthomas/participle/v2/lexer"
 )
 
+// DoubledUpJacksError returns when one or more jacks exist in many patches
+// yet shouldn't.
+//
+// This error may be incorrect for a number of reasons, including:
+//
+//  1. Not all jacks on a module have a unique name, such as the sequencer on a POM-400
+//  2. You're using a stacking jack, or a splitter, or a multiplier
+//
+// In these instances the solution is to:
+//
+//  1. Artificially number each jack, like 'output1', 'output2'
+//  2. Set `StackedPatches: true` in the synthdown.ValidationConfiguration struct
+//
+// passed to (SynthdownFile).Validate()
 type DoubledUpJacksError struct {
 	errs []doubledUpJackError
 }
 
+// Error returns a message indicating the number of errors found, plus the location
+// of each individual error
 func (e DoubledUpJacksError) Error() string {
 	errStrings := make([]string, len(e.errs))
 	for i, err := range e.errs {
@@ -59,6 +75,7 @@ func (m moduleJackMapping) addMapping(module, jack string, pos lexer.Position) {
 	m[module][jack] = append(m[module][jack], pos)
 }
 
+// errors combines every doubled-up jack into a single error for convenience
 func (m moduleJackMapping) errors() error {
 	errs := make([]doubledUpJackError, 0)
 

--- a/synthdown_file.go
+++ b/synthdown_file.go
@@ -1,0 +1,130 @@
+package synthdown
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/participle/v2/lexer"
+)
+
+type DoubledUpJacksError struct {
+	errs []doubledUpJackError
+}
+
+func (e DoubledUpJacksError) Error() string {
+	errStrings := make([]string, len(e.errs))
+	for i, err := range e.errs {
+		errStrings[i] = err.Error()
+	}
+
+	return fmt.Sprintf("%d error(s):\n%s", len(errStrings), strings.Join(errStrings, "\n"))
+}
+
+// doubledUpJackError returns when a specific jack on a module is
+// used more than once in a set of patches, and the ValidationConfiguration
+// passed to SynthdownFile.Validation doesn't have StackedPatches set to true.
+//
+// Default behvaiour is to assume that modules only have one jack by name
+type doubledUpJackError struct {
+	module, jack string
+	positions    []lexer.Position
+}
+
+// Error returns a string explaining where a named jack has been used more than once
+func (e doubledUpJackError) Error() string {
+	positions := make([]string, len(e.positions))
+	for i, pos := range e.positions {
+		positions[i] = pos.String()
+	}
+
+	return fmt.Sprintf("Jack %q on Module %q has been patched %d times: %s",
+		e.jack, e.module, len(positions), strings.Join(positions, ", "),
+	)
+}
+
+// moduleJackMapping tracks which named jacks are in use where, in order to validate
+// when jacks are used more than once
+type moduleJackMapping map[string]map[string][]lexer.Position
+
+// addMapping takes a module, a jack, and a position in a synthdown file
+func (m moduleJackMapping) addMapping(module, jack string, pos lexer.Position) {
+	if _, ok := m[module]; !ok {
+		m[module] = make(map[string][]lexer.Position)
+	}
+
+	if _, ok := m[module][jack]; !ok {
+		m[module][jack] = make([]lexer.Position, 0)
+	}
+
+	m[module][jack] = append(m[module][jack], pos)
+}
+
+func (m moduleJackMapping) errors() error {
+	errs := make([]doubledUpJackError, 0)
+
+	for module, jacks := range m {
+		for jack, positions := range jacks {
+			if len(positions) > 1 {
+				errs = append(errs, doubledUpJackError{module, jack, positions})
+			}
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return DoubledUpJacksError{errs}
+}
+
+// ValidationConfiguration holds options for enabling/ disabling
+// certain validation options.
+//
+// The default behaviour of any validation is to enable _every_
+// validation, which is why this struct is only ever passed as a
+// reference.
+type ValidationConfiguration struct {
+	// StackedPatches implies the use of multipliers/ splitter
+	// cables/ stacking plugs which allows us to, effectively,
+	// reuse input/output jacks on a module
+	StackedPatches bool
+}
+
+// SynthdownFile contains a list of Patches, which describe how
+// modular synth modules are wired to one another.
+type SynthdownFile struct {
+	Pos lexer.Position
+
+	Patches []Patch `parser:"( @@ ';' )*"`
+}
+
+// Validate runs through a fully read synthdown file in order to:
+//
+//  1. Run Patch.Validate() on each patch
+//  2. Ensure inputs and outputs aren't reused
+//
+// Note: checking input/ output reuse can be disabled when multipliers and/or
+// stacking patch cables are used. See the configuration struct passed to this
+// function for more information
+func (sf SynthdownFile) Validate(config *ValidationConfiguration) (err error) {
+	namedJacks := make(moduleJackMapping)
+
+	for _, patch := range sf.Patches {
+		err = patch.Validate()
+		if err != nil {
+			return
+		}
+
+		for _, module := range patch.Modules {
+			if module.Input != nil {
+				namedJacks.addMapping(module.Name, module.Input.Name, module.Input.Pos)
+			}
+
+			if module.Output != nil {
+				namedJacks.addMapping(module.Name, module.Output.Name, module.Output.Pos)
+			}
+		}
+	}
+
+	return namedJacks.errors()
+}

--- a/synthdown_file_test.go
+++ b/synthdown_file_test.go
@@ -1,0 +1,40 @@
+package synthdown
+
+import (
+	"testing"
+
+	"github.com/alecthomas/participle/v2/lexer"
+)
+
+func TestDoubledUpJacksError_Error(t *testing.T) {
+	err := DoubledUpJacksError{
+		errs: []doubledUpJackError{
+			{
+				module: "square wave",
+				jack:   "control",
+				positions: []lexer.Position{
+					{
+						Filename: "synthdown_file_test.go",
+						Offset:   0,
+						Line:     1,
+						Column:   1,
+					},
+					{
+						Filename: "synthdown_file_test.go",
+						Offset:   0,
+						Line:     5,
+						Column:   6,
+					},
+				},
+			},
+		},
+	}
+
+	expect := `1 error(s):
+Jack "control" on Module "square wave" has been patched 2 times: synthdown_file_test.go:1:1, synthdown_file_test.go:5:6`
+	received := err.Error()
+
+	if expect != received {
+		t.Errorf("expected\n%s\nreceived\n%s\n", expect, received)
+	}
+}

--- a/testdata/complex.sdown
+++ b/testdata/complex.sdown
@@ -1,3 +1,3 @@
-square[](out) -> (c1)mixer[c1:10, out:10](out) -> (in)speaker[](out);
-saw[](out) -> (c2)mixer[c2:10](out);
-sine[](out) -> (c3)mixer[c3:7.5](out);
+square[](out) -> (c1)mixer[c1:10, out:10](out) -> (in)speaker[];
+saw[](out) -> (c2)mixer[c2:10];
+sine[](out) -> (c3)mixer[c3:7.5];


### PR DESCRIPTION
Assuming that a module has a one to one mapping between jacks and their name (so: there's only one 'out' jack, for instance, or where there are many they're named in some way like 'out1'm 'out2') and that patches aren't using splitters or whatever then we need to make sure that an input or output is only defined once